### PR TITLE
docs: highlight uvx --from git one-shot install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 **Claude Code (easiest)** — just say:
 > "Install https://github.com/pixeltable/mcp-server-pixeltable-developer as a uv tool and add it to your MCPs"
 
+**One-shot (no install):**
+
+```bash
+uvx --from git+https://github.com/pixeltable/mcp-server-pixeltable-developer mcp-server-pixeltable-developer
+```
+
 **Manual install:**
 
 ```bash


### PR DESCRIPTION
## Summary
- Add a one-shot `uvx --from git+...` install line to Quick Start for MCP registry / client discovery.

## Test plan
- [x] README renders the new command block

Made with [Cursor](https://cursor.com)